### PR TITLE
 Fix invalid HTTP link to Wikipedia in `hom-edit.owl` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#HOM ontology
+# HOM ontology
 
 Welcome to the home for the ontology of homology and related concepts in biology, the HOM ontology. This ontology is developped in the context of the Bgee database (http://bgee.org/), and is used to provide annotations of similarity between anatomical structure (https://github.com/BgeeDB/anatomical-similarity-annotations). 
 

--- a/src/ontology/hom-edit.owl
+++ b/src/ontology/hom-edit.owl
@@ -973,7 +973,7 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Convergence that results from co-evolution usually involving an evolutionary arms race.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http:://en.wikipedia.org/wiki/Mimicry</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://en.wikipedia.org/wiki/Mimicry</oboInOwl:hasDbXref>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HOM_0000033"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
     </owl:Axiom>


### PR DESCRIPTION
Hi!

This is a hotfix for an invalid link in `hom` that also ends up in the OBO Relations Ontology (see [oborel/obo-relations#324](https://github.com/oborel/obo-relations/pull/324).

There are also some more issues to fix to make the `hom.obo` file compliant with the latest format version, but this one is the most urgent to fix; I'll open other PRs eventually.